### PR TITLE
refactor(week-1): a basic http server

### DIFF
--- a/1-breaking-API-changes/server.ts
+++ b/1-breaking-API-changes/server.ts
@@ -1,14 +1,15 @@
-import { serve } from '@hono/node-server';
-import { Hono } from 'hono';
+import { RequestListener, createServer } from 'http';
 import { search } from './capi.ts';
 
-const app = new Hono();
+const host = 'localhost';
+const port = 8000;
 
-app.get('/', async (c) => {
-	const query = c.req.query('q');
+const requestListener: RequestListener = async (request, response) => {
+	const url = new URL(request.url ?? '/', `http://${request.headers.host}`);
+	const query = url.searchParams.get('q');
 	const results = query ? await search(query) : [];
 
-	return c.html(`<!DOCTYPE html>
+	response.end(`<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -36,7 +37,9 @@ ${
     
 </body>
 </html>`);
-});
+};
 
-serve(app);
-console.log('Listening on http://localhost:3000/');
+const server = createServer(requestListener);
+server.listen(port, host, () => {
+	console.log(`Server is running on http://${host}:${port}`);
+});

--- a/1-breaking-API-changes/server.ts
+++ b/1-breaking-API-changes/server.ts
@@ -1,4 +1,4 @@
-import { RequestListener, createServer } from 'http';
+import { RequestListener, createServer } from 'node:http';
 import { search } from './capi.ts';
 
 const host = 'localhost';

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "typescript-school",
-			"license": "MIT",
+			"license": "Apache-2.0",
 			"devDependencies": {
 				"@guardian/package-linter": "0.5.3",
 				"@guardian/prettier": "5.0.0",
@@ -14,7 +14,6 @@
 				"@guardian/tsconfig": "0.2.0",
 				"@hono/node-server": "1.1.1",
 				"@types/node": "20.4.5",
-				"hono": "3.3.4",
 				"prettier": "3.0.0",
 				"ts-node": "10.9.1",
 				"tslib": "2.6.1",
@@ -197,15 +196,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.3.1"
-			}
-		},
-		"node_modules/hono": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-3.3.4.tgz",
-			"integrity": "sha512-lqvcsQrXS0bSydj/MkOXi3opAwrlauIjZefhXMMRj9prABfBWdrYHSrWk/xfxgxNPs4yuEMh2Z5zV0L2b1Jmdw==",
-			"dev": true,
-			"engines": {
-				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/isexe": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
 		"@guardian/tsconfig": "0.2.0",
 		"@hono/node-server": "1.1.1",
 		"@types/node": "20.4.5",
-		"hono": "3.3.4",
 		"prettier": "3.0.0",
 		"ts-node": "10.9.1",
 		"tslib": "2.6.1",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Drops `hono` in favour of a new URL(request.url, `http://${request.headers.host}`);.

## How to test

`npm run week-1-breaking-api-changes`

## How can we measure success?

Less surface area

## Have we considered potential risks?

The [Node API types are coming from the community](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node/v18).