### PR TITLE
Add Missing `hr` To Generics Slides

### DIFF
--- a/6-generics/slides.md
+++ b/6-generics/slides.md
@@ -148,6 +148,8 @@ const strings: Array<string> = ['news', 'opinion', 'culture'];
 const pillars: Array<Pillar> = [News, Opinion, Culture];
 ```
 
+---
+
 ## Writing Generic Types
 
 If you were writing the `Array` type yourself, it might look something like this:


### PR DESCRIPTION
Allows these to be recognised as slides.
