### PR TITLE
[Week 1]: handle “Labs”

### DIFF
--- a/1-breaking-API-changes/capi.ts
+++ b/1-breaking-API-changes/capi.ts
@@ -8,15 +8,19 @@ const fields = zod.object({
 });
 
 export type PillarId = zod.output<typeof pillarId>;
-const pillarId = zod.enum([
-	'pillar/news',
-	'pillar/opinion',
-	'pillar/sport',
-	'pillar/lifestyle',
-	'pillar/arts',
-	// @TODO: the pillar can be `undefined` for Labs
-	// Search for “Guardian”
-]);
+const pillarId = zod
+	.enum([
+		'pillar/news',
+		'pillar/opinion',
+		'pillar/sport',
+		'pillar/lifestyle',
+		'pillar/arts',
+		// @TODO: the pillar can be `undefined` for Labs
+		// Search for “Guardian”
+		'other/labs',
+	])
+	.optional()
+	.default('other/labs');
 
 /** **Concepts**: Generics */
 export type Result = zod.output<typeof result>;

--- a/1-breaking-API-changes/pillars.ts
+++ b/1-breaking-API-changes/pillars.ts
@@ -1,5 +1,5 @@
 import { palette } from '@guardian/source-foundations';
-import { PillarId } from './capi';
+import { PillarId } from './capi.ts';
 /**
  * **Concepts**: Generics
  *
@@ -21,7 +21,7 @@ type PaletteColour<T extends keyof typeof palette> =
  */
 type Pillar = Extract<
 	keyof typeof palette,
-	'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle'
+	'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle' | 'labs'
 	// @TODO we need to account for 'labs'
 >;
 
@@ -53,6 +53,12 @@ const styles = {
 	lifestyle: {
 		border: palette.lifestyle[400],
 		headline: palette.lifestyle[300],
+		text: palette.neutral[10],
+		background: palette.neutral[97],
+	},
+	labs: {
+		border: palette.labs[400],
+		headline: palette.labs[300],
 		text: palette.neutral[10],
 		background: palette.neutral[97],
 	},
@@ -97,4 +103,5 @@ export const pillarMappings = {
 	'pillar/sport': 'sport',
 	'pillar/lifestyle': 'lifestyle',
 	'pillar/arts': 'culture',
+	'other/labs': 'labs',
 } as const satisfies Record<PillarId, Pillar>;


### PR DESCRIPTION
## What does this change

Handle parsing errors when results contain Labs articles, which do not have a pillar.

It’s a working solution to the exercise of “Week 1: Breaking API changes”.