### PR TITLE
[typescript/narrowing] add two slides (`in` operator & `is` keyword)

### DIFF
--- a/typescript/3-narrowing/slides.md
+++ b/typescript/3-narrowing/slides.md
@@ -666,3 +666,28 @@ function move(animal: Fish | Bird) {
   return animal.fly();
 }
 ```
+
+---
+
+## Custom narrowing with the `is` keyword
+
+```ts
+type Fish = { swim: () => void };
+type Bird = { fly: () => void };
+type Animal = Fish | Bird;
+
+const isFish = (maybeAnimal: Animal | null): maybeAnimal is Fish => {
+  return !!maybeAnimal && "swim" in maybeAnimal;
+}
+
+function isBird(maybeAnimal: Animal | null): maybeAnimal is Bird {
+  return !!maybeAnimal && "fly" in maybeAnimal;
+}
+ 
+function move(animal: Fish | Bird) {
+  if (isFish(animal)) {
+    return animal.swim();
+  }
+  return animal.fly();
+}
+```

--- a/typescript/3-narrowing/slides.md
+++ b/typescript/3-narrowing/slides.md
@@ -1,4 +1,4 @@
-# Narrowing
+# Narrowing (a.k.a. Type Guards)
 
 There's a chapter covering narrowing in the TypeScript handbook: https://www.typescriptlang.org/docs/handbook/2/narrowing.html
 

--- a/typescript/3-narrowing/slides.md
+++ b/typescript/3-narrowing/slides.md
@@ -649,3 +649,20 @@ const logElement = (element: Element): string => {
 <!--omit-from-slides start-->
 When `kind` is `'Image'` TypeScript knows that it can narrow the type of `Element` to an `Image` and allow access to the `width` and `height` fields. When `kind` is `'Text'` TypeScript knows that it can narrow the type of `Element` to `Text` and allow access to the `copy` field.
 <!--omit-from-slides end-->
+
+---
+
+## `in` operator narrowing
+
+```ts
+type Fish = { swim: () => void };
+type Bird = { fly: () => void };
+ 
+function move(animal: Fish | Bird) {
+  if ("swim" in animal) {
+    return animal.swim();
+  }
+ 
+  return animal.fly();
+}
+```


### PR DESCRIPTION
Add two slides to the Typescript narrowing deck...

- `in` operator
- custom narrowing with the `is` keyword